### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ Then, you can build lib60870 with:
   $ cd build
   $ cmake ..
   $ make
+  $ make install
 
 
 


### PR DESCRIPTION
Add missing step to install the lib60870, otherwise plugin will not compile.